### PR TITLE
FIX width of transform component content

### DIFF
--- a/Assets/BitStrap/Plugins/Inspector/Editor/TransformEditor.cs
+++ b/Assets/BitStrap/Plugins/Inspector/Editor/TransformEditor.cs
@@ -11,7 +11,6 @@ namespace BitStrap
 	public class TransformEditor : Editor
 	{
 		private const float FIELD_WIDTH = 212.0f;
-		private const bool WIDE_MODE = true;
 
 		private const float POSITION_MAX = 100000.0f;
 
@@ -61,10 +60,12 @@ namespace BitStrap
 
 		public override void OnInspectorGUI()
 		{
-			EditorGUIUtility.wideMode = WIDE_MODE;
-			EditorGUIUtility.labelWidth = EditorGUIUtility.currentViewWidth - FIELD_WIDTH; // align field to right of inspector
-
-			serializedObject.Update();
+		    if (!EditorGUIUtility.wideMode)
+		    {
+		        EditorGUIUtility.wideMode = true;
+                EditorGUIUtility.labelWidth = EditorGUIUtility.currentViewWidth - FIELD_WIDTH; // align field to right of inspector
+		    }
+		    serializedObject.Update();
 
 			BeginPropertyWithReset();
 			EditorGUILayout.PropertyField( positionProperty, positionGUIContent );


### PR DESCRIPTION
I took a look at how unity does it (https://github.com/MattRix/UnityDecompiled/blob/master/UnityEditor/UnityEditor/TransformInspector.cs) and changed the inspector so it works the same way. Here is the difference:
![change](https://user-images.githubusercontent.com/4518980/33242803-b022da48-d2da-11e7-8420-aa1001df2020.png)

Btw. I love the buttons on the right, really good addition to the inspector!